### PR TITLE
Check the MaterialName with the Name of an Object

### DIFF
--- a/Mag-Tools/PluginCore.cs
+++ b/Mag-Tools/PluginCore.cs
@@ -1311,6 +1311,18 @@ namespace MagTools
 			return null;
 		}
 
+        bool CompareItemNameString(WorldObject wo, String name, bool partial)
+        {
+            MyWorldObject mwo = MyWorldObjectCreator.Create(wo);
+            String fullItemName = mwo.Material == null ? mwo.Name : mwo.Material + " " + mwo.Name;
+            if (partial)
+                return fullItemName.ToLower().Contains(name.ToLower());
+            else
+                // retain legacy behavior but also add material name comparison 
+                return String.Compare(wo.Name, name, StringComparison.OrdinalIgnoreCase) == 0 || 
+                    String.Compare(fullItemName, name, StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
 		int FindIdForName(string name, bool searchInInventory, bool searchOpenContainer, bool searchEnvironment, bool partialMatch, int idToSkip = 0)
 		{
 			// Exact match attempt first
@@ -1318,7 +1330,7 @@ namespace MagTools
 			{
 				foreach (WorldObject wo in CoreManager.Current.WorldFilter.GetInventory())
 				{
-					if (String.Compare(wo.Name, name, StringComparison.OrdinalIgnoreCase) == 0 && wo.Id != idToSkip)
+					if (CompareItemNameString(wo, name, false) && wo.Id != idToSkip)
 						return wo.Id;
 				}
 			}
@@ -1327,7 +1339,7 @@ namespace MagTools
 			{
 				foreach (WorldObject wo in CoreManager.Current.WorldFilter.GetByContainer(CoreManager.Current.Actions.OpenedContainer))
 				{
-					if (String.Compare(wo.Name, name, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (CompareItemNameString(wo, name, false))
 						return wo.Id;
 				}
 			}
@@ -1356,7 +1368,7 @@ namespace MagTools
 				{
 					foreach (WorldObject wo in CoreManager.Current.WorldFilter.GetByContainer(CoreManager.Current.Actions.OpenedContainer))
 					{
-						if (wo.Name.ToLower().Contains(name.ToLower()))
+                        if (CompareItemNameString(wo, name, true))
 							return wo.Id;
 					}
 				}


### PR DESCRIPTION
Right now, only the base name of an object is checked when you use /mt give /mt givep, etc. This should also check the MaterialName so that bags of salvage can be distinguished from their base name of "Salvage". This PR maintains current behavior but adds an additional check for the object name that is prefixed with the material name.

I did this for a guildie on Coldeve in order for him to /givep Jet Salvage, etc. and thought others might like to use it.