### PR TITLE
feature: Granular activation and wield filters for arcane lore and defense skills.

### DIFF
--- a/Mag-SuitBuilder/Equipment/FiltersControl.Designer.cs
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.Designer.cs
@@ -28,6 +28,8 @@ namespace Mag_SuitBuilder.Equipment
 		/// </summary>
 		private void InitializeComponent()
 		{
+			components = new System.ComponentModel.Container();
+			var resources = new System.ComponentModel.ComponentResourceManager(typeof(FiltersControl));
 			checkRemoveEquipped = new System.Windows.Forms.CheckBox();
 			chkRemoveUnequipped = new System.Windows.Forms.CheckBox();
 			chkBodyArmorClothing = new System.Windows.Forms.CheckBox();
@@ -59,7 +61,7 @@ namespace Mag_SuitBuilder.Equipment
 			chkCompsKitsFoodManaStones = new System.Windows.Forms.CheckBox();
 			chkPets = new System.Windows.Forms.CheckBox();
 			chkAllElseObjectClasses = new System.Windows.Forms.CheckBox();
-			cantripSelectorControl1 = new Spells.CantripSelectorControl();
+			cantripSelectorControl1 = new Mag_SuitBuilder.Spells.CantripSelectorControl();
 			txtRegexStringMatch = new System.Windows.Forms.TextBox();
 			label1 = new System.Windows.Forms.Label();
 			cmdApplyRegexStringMatch = new System.Windows.Forms.Button();
@@ -115,6 +117,34 @@ namespace Mag_SuitBuilder.Equipment
 			txtWieldRequirementLevelMin = new System.Windows.Forms.TextBox();
 			label26 = new System.Windows.Forms.Label();
 			txtWieldRequirementLevelMax = new System.Windows.Forms.TextBox();
+			label27 = new System.Windows.Forms.Label();
+			label28 = new System.Windows.Forms.Label();
+			txtMissileDefActMin = new System.Windows.Forms.TextBox();
+			label29 = new System.Windows.Forms.Label();
+			txtMissileDefActMax = new System.Windows.Forms.TextBox();
+			label30 = new System.Windows.Forms.Label();
+			txtArcaneLoreActMin = new System.Windows.Forms.TextBox();
+			label31 = new System.Windows.Forms.Label();
+			txtArcaneLoreActMax = new System.Windows.Forms.TextBox();
+			label32 = new System.Windows.Forms.Label();
+			txtMeleeDefActMin = new System.Windows.Forms.TextBox();
+			label33 = new System.Windows.Forms.Label();
+			txtMeleeDefActMax = new System.Windows.Forms.TextBox();
+			label34 = new System.Windows.Forms.Label();
+			txtMissileDefWldMin = new System.Windows.Forms.TextBox();
+			label35 = new System.Windows.Forms.Label();
+			txtMissileDefWldMax = new System.Windows.Forms.TextBox();
+			label36 = new System.Windows.Forms.Label();
+			txtMeleeDefWldMin = new System.Windows.Forms.TextBox();
+			label37 = new System.Windows.Forms.Label();
+			txtMeleeDefWldMax = new System.Windows.Forms.TextBox();
+			label38 = new System.Windows.Forms.Label();
+			txtMagicDefWldMin = new System.Windows.Forms.TextBox();
+			label39 = new System.Windows.Forms.Label();
+			txtMagicDefWldMax = new System.Windows.Forms.TextBox();
+			label40 = new System.Windows.Forms.Label();
+			toolTip1 = new System.Windows.Forms.ToolTip(components);
+			toolTip2 = new System.Windows.Forms.ToolTip(components);
 			SuspendLayout();
 			// 
 			// checkRemoveEquipped
@@ -198,7 +228,7 @@ namespace Mag_SuitBuilder.Equipment
 			chkJewelryTrinket.CheckState = System.Windows.Forms.CheckState.Checked;
 			chkJewelryTrinket.Location = new System.Drawing.Point(92, 137);
 			chkJewelryTrinket.Name = "chkJewelryTrinket";
-			chkJewelryTrinket.Size = new System.Drawing.Size(61, 19);
+			chkJewelryTrinket.Size = new System.Drawing.Size(62, 19);
 			chkJewelryTrinket.TabIndex = 6;
 			chkJewelryTrinket.Text = "Trinket";
 			chkJewelryTrinket.UseVisualStyleBackColor = true;
@@ -328,7 +358,7 @@ namespace Mag_SuitBuilder.Equipment
 			chkMasteryAxe.CheckState = System.Windows.Forms.CheckState.Checked;
 			chkMasteryAxe.Location = new System.Drawing.Point(125, 212);
 			chkMasteryAxe.Name = "chkMasteryAxe";
-			chkMasteryAxe.Size = new System.Drawing.Size(46, 19);
+			chkMasteryAxe.Size = new System.Drawing.Size(45, 19);
 			chkMasteryAxe.TabIndex = 16;
 			chkMasteryAxe.Text = "Axe";
 			chkMasteryAxe.UseVisualStyleBackColor = true;
@@ -393,7 +423,7 @@ namespace Mag_SuitBuilder.Equipment
 			chkMasteryThrown.CheckState = System.Windows.Forms.CheckState.Checked;
 			chkMasteryThrown.Location = new System.Drawing.Point(151, 262);
 			chkMasteryThrown.Name = "chkMasteryThrown";
-			chkMasteryThrown.Size = new System.Drawing.Size(66, 19);
+			chkMasteryThrown.Size = new System.Drawing.Size(67, 19);
 			chkMasteryThrown.TabIndex = 21;
 			chkMasteryThrown.Text = "Thrown";
 			chkMasteryThrown.UseVisualStyleBackColor = true;
@@ -476,9 +506,9 @@ namespace Mag_SuitBuilder.Equipment
 			chkCompsKitsFoodManaStones.AutoSize = true;
 			chkCompsKitsFoodManaStones.Location = new System.Drawing.Point(3, 412);
 			chkCompsKitsFoodManaStones.Name = "chkCompsKitsFoodManaStones";
-			chkCompsKitsFoodManaStones.Size = new System.Drawing.Size(223, 19);
+			chkCompsKitsFoodManaStones.Size = new System.Drawing.Size(193, 19);
 			chkCompsKitsFoodManaStones.TabIndex = 28;
-			chkCompsKitsFoodManaStones.Text = "Comps && Kits && Food && ManaStones";
+			chkCompsKitsFoodManaStones.Text = "Comps, Kits, Food, ManaStones";
 			chkCompsKitsFoodManaStones.UseVisualStyleBackColor = true;
 			chkCompsKitsFoodManaStones.CheckedChanged += chkFilter_CheckedChanged;
 			// 
@@ -526,7 +556,7 @@ namespace Mag_SuitBuilder.Equipment
 			label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
 			label1.Location = new System.Drawing.Point(3, 493);
 			label1.Name = "label1";
-			label1.Size = new System.Drawing.Size(110, 15);
+			label1.Size = new System.Drawing.Size(109, 15);
 			label1.TabIndex = 33;
 			label1.Text = "Regex String Match";
 			// 
@@ -592,7 +622,7 @@ namespace Mag_SuitBuilder.Equipment
 			label5.AutoSize = true;
 			label5.Location = new System.Drawing.Point(289, 102);
 			label5.Name = "label5";
-			label5.Size = new System.Drawing.Size(154, 15);
+			label5.Size = new System.Drawing.Size(153, 15);
 			label5.TabIndex = 40;
 			label5.Text = "Base Extremity Armor Level:";
 			// 
@@ -719,7 +749,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMinLegendaries
 			// 
-			txtMinLegendaries.Location = new System.Drawing.Point(475, 213);
+			txtMinLegendaries.Location = new System.Drawing.Point(478, 213);
 			txtMinLegendaries.MaxLength = 1;
 			txtMinLegendaries.Name = "txtMinLegendaries";
 			txtMinLegendaries.Size = new System.Drawing.Size(23, 23);
@@ -739,7 +769,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxLegendaries
 			// 
-			txtMaxLegendaries.Location = new System.Drawing.Point(552, 213);
+			txtMaxLegendaries.Location = new System.Drawing.Point(549, 213);
 			txtMaxLegendaries.MaxLength = 1;
 			txtMaxLegendaries.Name = "txtMaxLegendaries";
 			txtMaxLegendaries.Size = new System.Drawing.Size(23, 23);
@@ -751,7 +781,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label9
 			// 
 			label9.AutoSize = true;
-			label9.Location = new System.Drawing.Point(404, 216);
+			label9.Location = new System.Drawing.Point(409, 216);
 			label9.Name = "label9";
 			label9.Size = new System.Drawing.Size(65, 15);
 			label9.TabIndex = 55;
@@ -761,7 +791,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			label10.AutoSize = true;
 			label10.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
-			label10.Location = new System.Drawing.Point(491, 191);
+			label10.Location = new System.Drawing.Point(488, 191);
 			label10.Name = "label10";
 			label10.Size = new System.Drawing.Size(89, 15);
 			label10.TabIndex = 56;
@@ -770,7 +800,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label11
 			// 
 			label11.AutoSize = true;
-			label11.Location = new System.Drawing.Point(437, 245);
+			label11.Location = new System.Drawing.Point(442, 245);
 			label11.Name = "label11";
 			label11.Size = new System.Drawing.Size(32, 15);
 			label11.TabIndex = 60;
@@ -778,7 +808,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMinEpics
 			// 
-			txtMinEpics.Location = new System.Drawing.Point(475, 242);
+			txtMinEpics.Location = new System.Drawing.Point(478, 242);
 			txtMinEpics.MaxLength = 1;
 			txtMinEpics.Name = "txtMinEpics";
 			txtMinEpics.Size = new System.Drawing.Size(23, 23);
@@ -798,7 +828,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxEpics
 			// 
-			txtMaxEpics.Location = new System.Drawing.Point(552, 242);
+			txtMaxEpics.Location = new System.Drawing.Point(549, 242);
 			txtMaxEpics.MaxLength = 1;
 			txtMaxEpics.Name = "txtMaxEpics";
 			txtMaxEpics.Size = new System.Drawing.Size(23, 23);
@@ -810,7 +840,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label13
 			// 
 			label13.AutoSize = true;
-			label13.Location = new System.Drawing.Point(408, 331);
+			label13.Location = new System.Drawing.Point(413, 331);
 			label13.Name = "label13";
 			label13.Size = new System.Drawing.Size(61, 15);
 			label13.TabIndex = 69;
@@ -818,7 +848,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMinDefensiveRating
 			// 
-			txtMinDefensiveRating.Location = new System.Drawing.Point(475, 328);
+			txtMinDefensiveRating.Location = new System.Drawing.Point(478, 328);
 			txtMinDefensiveRating.MaxLength = 1;
 			txtMinDefensiveRating.Name = "txtMinDefensiveRating";
 			txtMinDefensiveRating.Size = new System.Drawing.Size(23, 23);
@@ -838,7 +868,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxDefensiveRating
 			// 
-			txtMaxDefensiveRating.Location = new System.Drawing.Point(552, 328);
+			txtMaxDefensiveRating.Location = new System.Drawing.Point(549, 328);
 			txtMaxDefensiveRating.MaxLength = 1;
 			txtMaxDefensiveRating.Name = "txtMaxDefensiveRating";
 			txtMaxDefensiveRating.Size = new System.Drawing.Size(23, 23);
@@ -851,7 +881,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			label15.AutoSize = true;
 			label15.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
-			label15.Location = new System.Drawing.Point(532, 277);
+			label15.Location = new System.Drawing.Point(529, 277);
 			label15.Name = "label15";
 			label15.Size = new System.Drawing.Size(46, 15);
 			label15.TabIndex = 65;
@@ -860,7 +890,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label16
 			// 
 			label16.AutoSize = true;
-			label16.Location = new System.Drawing.Point(409, 302);
+			label16.Location = new System.Drawing.Point(414, 302);
 			label16.Name = "label16";
 			label16.Size = new System.Drawing.Size(60, 15);
 			label16.TabIndex = 64;
@@ -868,7 +898,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMinOffensiveRating
 			// 
-			txtMinOffensiveRating.Location = new System.Drawing.Point(475, 299);
+			txtMinOffensiveRating.Location = new System.Drawing.Point(478, 299);
 			txtMinOffensiveRating.MaxLength = 1;
 			txtMinOffensiveRating.Name = "txtMinOffensiveRating";
 			txtMinOffensiveRating.Size = new System.Drawing.Size(23, 23);
@@ -888,7 +918,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxOffensiveRating
 			// 
-			txtMaxOffensiveRating.Location = new System.Drawing.Point(552, 299);
+			txtMaxOffensiveRating.Location = new System.Drawing.Point(549, 299);
 			txtMaxOffensiveRating.MaxLength = 1;
 			txtMaxOffensiveRating.Name = "txtMaxOffensiveRating";
 			txtMaxOffensiveRating.Size = new System.Drawing.Size(23, 23);
@@ -900,15 +930,15 @@ namespace Mag_SuitBuilder.Equipment
 			// label18
 			// 
 			label18.AutoSize = true;
-			label18.Location = new System.Drawing.Point(434, 389);
+			label18.Location = new System.Drawing.Point(439, 389);
 			label18.Name = "label18";
-			label18.Size = new System.Drawing.Size(35, 15);
+			label18.Size = new System.Drawing.Size(36, 15);
 			label18.TabIndex = 77;
 			label18.Text = "Total:";
 			// 
 			// txtMinTotalRating
 			// 
-			txtMinTotalRating.Location = new System.Drawing.Point(475, 386);
+			txtMinTotalRating.Location = new System.Drawing.Point(478, 386);
 			txtMinTotalRating.MaxLength = 1;
 			txtMinTotalRating.Name = "txtMinTotalRating";
 			txtMinTotalRating.Size = new System.Drawing.Size(23, 23);
@@ -928,7 +958,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxTotalRating
 			// 
-			txtMaxTotalRating.Location = new System.Drawing.Point(552, 386);
+			txtMaxTotalRating.Location = new System.Drawing.Point(549, 386);
 			txtMaxTotalRating.MaxLength = 1;
 			txtMaxTotalRating.Name = "txtMaxTotalRating";
 			txtMaxTotalRating.Size = new System.Drawing.Size(23, 23);
@@ -940,7 +970,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label20
 			// 
 			label20.AutoSize = true;
-			label20.Location = new System.Drawing.Point(429, 360);
+			label20.Location = new System.Drawing.Point(434, 360);
 			label20.Name = "label20";
 			label20.Size = new System.Drawing.Size(40, 15);
 			label20.TabIndex = 73;
@@ -948,7 +978,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMinOtherRating
 			// 
-			txtMinOtherRating.Location = new System.Drawing.Point(475, 357);
+			txtMinOtherRating.Location = new System.Drawing.Point(478, 357);
 			txtMinOtherRating.MaxLength = 1;
 			txtMinOtherRating.Name = "txtMinOtherRating";
 			txtMinOtherRating.Size = new System.Drawing.Size(23, 23);
@@ -968,7 +998,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtMaxOtherRating
 			// 
-			txtMaxOtherRating.Location = new System.Drawing.Point(552, 357);
+			txtMaxOtherRating.Location = new System.Drawing.Point(549, 357);
 			txtMaxOtherRating.MaxLength = 1;
 			txtMaxOtherRating.Name = "txtMaxOtherRating";
 			txtMaxOtherRating.Size = new System.Drawing.Size(23, 23);
@@ -980,7 +1010,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label22
 			// 
 			label22.AutoSize = true;
-			label22.Location = new System.Drawing.Point(412, 470);
+			label22.Location = new System.Drawing.Point(417, 470);
 			label22.Name = "label22";
 			label22.Size = new System.Drawing.Size(31, 15);
 			label22.TabIndex = 86;
@@ -988,7 +1018,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtWieldRequirementSkillMin
 			// 
-			txtWieldRequirementSkillMin.Location = new System.Drawing.Point(449, 467);
+			txtWieldRequirementSkillMin.Location = new System.Drawing.Point(452, 467);
 			txtWieldRequirementSkillMin.MaxLength = 3;
 			txtWieldRequirementSkillMin.Name = "txtWieldRequirementSkillMin";
 			txtWieldRequirementSkillMin.Size = new System.Drawing.Size(36, 23);
@@ -1008,7 +1038,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtWieldRequirementSkillMax
 			// 
-			txtWieldRequirementSkillMax.Location = new System.Drawing.Point(539, 467);
+			txtWieldRequirementSkillMax.Location = new System.Drawing.Point(536, 467);
 			txtWieldRequirementSkillMax.MaxLength = 3;
 			txtWieldRequirementSkillMax.Name = "txtWieldRequirementSkillMax";
 			txtWieldRequirementSkillMax.Size = new System.Drawing.Size(36, 23);
@@ -1030,7 +1060,7 @@ namespace Mag_SuitBuilder.Equipment
 			// label25
 			// 
 			label25.AutoSize = true;
-			label25.Location = new System.Drawing.Point(406, 441);
+			label25.Location = new System.Drawing.Point(411, 441);
 			label25.Name = "label25";
 			label25.Size = new System.Drawing.Size(37, 15);
 			label25.TabIndex = 81;
@@ -1038,7 +1068,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtWieldRequirementLevelMin
 			// 
-			txtWieldRequirementLevelMin.Location = new System.Drawing.Point(449, 438);
+			txtWieldRequirementLevelMin.Location = new System.Drawing.Point(452, 438);
 			txtWieldRequirementLevelMin.MaxLength = 3;
 			txtWieldRequirementLevelMin.Name = "txtWieldRequirementLevelMin";
 			txtWieldRequirementLevelMin.Size = new System.Drawing.Size(36, 23);
@@ -1058,7 +1088,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			// txtWieldRequirementLevelMax
 			// 
-			txtWieldRequirementLevelMax.Location = new System.Drawing.Point(539, 438);
+			txtWieldRequirementLevelMax.Location = new System.Drawing.Point(536, 438);
 			txtWieldRequirementLevelMax.MaxLength = 3;
 			txtWieldRequirementLevelMax.Name = "txtWieldRequirementLevelMax";
 			txtWieldRequirementLevelMax.Size = new System.Drawing.Size(36, 23);
@@ -1067,10 +1097,306 @@ namespace Mag_SuitBuilder.Equipment
 			txtWieldRequirementLevelMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
 			txtWieldRequirementLevelMax.TextChanged += txtFilter_TextChanged;
 			// 
+			// label27
+			// 
+			label27.AutoSize = true;
+			label27.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
+			label27.Location = new System.Drawing.Point(271, 256);
+			label27.Name = "label27";
+			label27.Size = new System.Drawing.Size(137, 15);
+			label27.TabIndex = 87;
+			label27.Text = "Activation Requirements";
+			toolTip1.SetToolTip(label27, resources.GetString("label27.ToolTip"));
+			// 
+			// label28
+			// 
+			label28.AutoSize = true;
+			label28.Location = new System.Drawing.Point(188, 339);
+			label28.Name = "label28";
+			label28.Size = new System.Drawing.Size(91, 15);
+			label28.TabIndex = 91;
+			label28.Text = "Missile Defense:";
+			// 
+			// txtMissileDefActMin
+			// 
+			txtMissileDefActMin.Location = new System.Drawing.Point(283, 336);
+			txtMissileDefActMin.MaxLength = 3;
+			txtMissileDefActMin.Name = "txtMissileDefActMin";
+			txtMissileDefActMin.Size = new System.Drawing.Size(36, 23);
+			txtMissileDefActMin.TabIndex = 90;
+			txtMissileDefActMin.Text = "0";
+			txtMissileDefActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMissileDefActMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label29
+			// 
+			label29.AutoSize = true;
+			label29.Location = new System.Drawing.Point(322, 339);
+			label29.Name = "label29";
+			label29.Size = new System.Drawing.Size(42, 15);
+			label29.TabIndex = 89;
+			label29.Text = ">= =<";
+			// 
+			// txtMissileDefActMax
+			// 
+			txtMissileDefActMax.Location = new System.Drawing.Point(367, 336);
+			txtMissileDefActMax.MaxLength = 3;
+			txtMissileDefActMax.Name = "txtMissileDefActMax";
+			txtMissileDefActMax.Size = new System.Drawing.Size(36, 23);
+			txtMissileDefActMax.TabIndex = 88;
+			txtMissileDefActMax.Text = "999";
+			txtMissileDefActMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMissileDefActMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label30
+			// 
+			label30.AutoSize = true;
+			label30.Location = new System.Drawing.Point(206, 281);
+			label30.Name = "label30";
+			label30.Size = new System.Drawing.Size(73, 15);
+			label30.TabIndex = 95;
+			label30.Text = "Arcane Lore:";
+			// 
+			// txtArcaneLoreActMin
+			// 
+			txtArcaneLoreActMin.Location = new System.Drawing.Point(283, 278);
+			txtArcaneLoreActMin.MaxLength = 3;
+			txtArcaneLoreActMin.Name = "txtArcaneLoreActMin";
+			txtArcaneLoreActMin.Size = new System.Drawing.Size(36, 23);
+			txtArcaneLoreActMin.TabIndex = 94;
+			txtArcaneLoreActMin.Text = "0";
+			txtArcaneLoreActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtArcaneLoreActMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label31
+			// 
+			label31.AutoSize = true;
+			label31.Location = new System.Drawing.Point(322, 281);
+			label31.Name = "label31";
+			label31.Size = new System.Drawing.Size(42, 15);
+			label31.TabIndex = 93;
+			label31.Text = ">= =<";
+			// 
+			// txtArcaneLoreActMax
+			// 
+			txtArcaneLoreActMax.Location = new System.Drawing.Point(367, 278);
+			txtArcaneLoreActMax.MaxLength = 3;
+			txtArcaneLoreActMax.Name = "txtArcaneLoreActMax";
+			txtArcaneLoreActMax.Size = new System.Drawing.Size(36, 23);
+			txtArcaneLoreActMax.TabIndex = 92;
+			txtArcaneLoreActMax.Text = "999";
+			txtArcaneLoreActMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtArcaneLoreActMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label32
+			// 
+			label32.AutoSize = true;
+			label32.Location = new System.Drawing.Point(192, 310);
+			label32.Name = "label32";
+			label32.Size = new System.Drawing.Size(87, 15);
+			label32.TabIndex = 99;
+			label32.Text = "Melee Defense:";
+			// 
+			// txtMeleeDefActMin
+			// 
+			txtMeleeDefActMin.Location = new System.Drawing.Point(283, 307);
+			txtMeleeDefActMin.MaxLength = 3;
+			txtMeleeDefActMin.Name = "txtMeleeDefActMin";
+			txtMeleeDefActMin.Size = new System.Drawing.Size(36, 23);
+			txtMeleeDefActMin.TabIndex = 98;
+			txtMeleeDefActMin.Text = "0";
+			txtMeleeDefActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMeleeDefActMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label33
+			// 
+			label33.AutoSize = true;
+			label33.Location = new System.Drawing.Point(322, 310);
+			label33.Name = "label33";
+			label33.Size = new System.Drawing.Size(42, 15);
+			label33.TabIndex = 97;
+			label33.Text = ">= =<";
+			// 
+			// txtMeleeDefActMax
+			// 
+			txtMeleeDefActMax.Location = new System.Drawing.Point(367, 307);
+			txtMeleeDefActMax.MaxLength = 3;
+			txtMeleeDefActMax.Name = "txtMeleeDefActMax";
+			txtMeleeDefActMax.Size = new System.Drawing.Size(36, 23);
+			txtMeleeDefActMax.TabIndex = 96;
+			txtMeleeDefActMax.Text = "999";
+			txtMeleeDefActMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMeleeDefActMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label34
+			// 
+			label34.AutoSize = true;
+			label34.Location = new System.Drawing.Point(187, 447);
+			label34.Name = "label34";
+			label34.Size = new System.Drawing.Size(91, 15);
+			label34.TabIndex = 112;
+			label34.Text = "Missile Defense:";
+			// 
+			// txtMissileDefWldMin
+			// 
+			txtMissileDefWldMin.Location = new System.Drawing.Point(282, 444);
+			txtMissileDefWldMin.MaxLength = 3;
+			txtMissileDefWldMin.Name = "txtMissileDefWldMin";
+			txtMissileDefWldMin.Size = new System.Drawing.Size(36, 23);
+			txtMissileDefWldMin.TabIndex = 111;
+			txtMissileDefWldMin.Text = "0";
+			txtMissileDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMissileDefWldMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label35
+			// 
+			label35.AutoSize = true;
+			label35.Location = new System.Drawing.Point(322, 447);
+			label35.Name = "label35";
+			label35.Size = new System.Drawing.Size(42, 15);
+			label35.TabIndex = 110;
+			label35.Text = ">= =<";
+			// 
+			// txtMissileDefWldMax
+			// 
+			txtMissileDefWldMax.Location = new System.Drawing.Point(367, 444);
+			txtMissileDefWldMax.MaxLength = 3;
+			txtMissileDefWldMax.Name = "txtMissileDefWldMax";
+			txtMissileDefWldMax.Size = new System.Drawing.Size(36, 23);
+			txtMissileDefWldMax.TabIndex = 109;
+			txtMissileDefWldMax.Text = "999";
+			txtMissileDefWldMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMissileDefWldMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label36
+			// 
+			label36.AutoSize = true;
+			label36.Location = new System.Drawing.Point(192, 418);
+			label36.Name = "label36";
+			label36.Size = new System.Drawing.Size(87, 15);
+			label36.TabIndex = 108;
+			label36.Text = "Melee Defense:";
+			// 
+			// txtMeleeDefWldMin
+			// 
+			txtMeleeDefWldMin.Location = new System.Drawing.Point(282, 415);
+			txtMeleeDefWldMin.MaxLength = 3;
+			txtMeleeDefWldMin.Name = "txtMeleeDefWldMin";
+			txtMeleeDefWldMin.Size = new System.Drawing.Size(36, 23);
+			txtMeleeDefWldMin.TabIndex = 107;
+			txtMeleeDefWldMin.Text = "0";
+			txtMeleeDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMeleeDefWldMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label37
+			// 
+			label37.AutoSize = true;
+			label37.Location = new System.Drawing.Point(322, 418);
+			label37.Name = "label37";
+			label37.Size = new System.Drawing.Size(42, 15);
+			label37.TabIndex = 106;
+			label37.Text = ">= =<";
+			// 
+			// txtMeleeDefWldMax
+			// 
+			txtMeleeDefWldMax.Location = new System.Drawing.Point(367, 415);
+			txtMeleeDefWldMax.MaxLength = 3;
+			txtMeleeDefWldMax.Name = "txtMeleeDefWldMax";
+			txtMeleeDefWldMax.Size = new System.Drawing.Size(36, 23);
+			txtMeleeDefWldMax.TabIndex = 105;
+			txtMeleeDefWldMax.Text = "999";
+			txtMeleeDefWldMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMeleeDefWldMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label38
+			// 
+			label38.AutoSize = true;
+			label38.Location = new System.Drawing.Point(190, 476);
+			label38.Name = "label38";
+			label38.Size = new System.Drawing.Size(88, 15);
+			label38.TabIndex = 104;
+			label38.Text = "Magic Defense:";
+			// 
+			// txtMagicDefWldMin
+			// 
+			txtMagicDefWldMin.Location = new System.Drawing.Point(282, 473);
+			txtMagicDefWldMin.MaxLength = 3;
+			txtMagicDefWldMin.Name = "txtMagicDefWldMin";
+			txtMagicDefWldMin.Size = new System.Drawing.Size(36, 23);
+			txtMagicDefWldMin.TabIndex = 103;
+			txtMagicDefWldMin.Text = "0";
+			txtMagicDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMagicDefWldMin.TextChanged += txtFilter_TextChanged;
+			// 
+			// label39
+			// 
+			label39.AutoSize = true;
+			label39.Location = new System.Drawing.Point(322, 476);
+			label39.Name = "label39";
+			label39.Size = new System.Drawing.Size(42, 15);
+			label39.TabIndex = 102;
+			label39.Text = ">= =<";
+			// 
+			// txtMagicDefWldMax
+			// 
+			txtMagicDefWldMax.Location = new System.Drawing.Point(367, 473);
+			txtMagicDefWldMax.MaxLength = 3;
+			txtMagicDefWldMax.Name = "txtMagicDefWldMax";
+			txtMagicDefWldMax.Size = new System.Drawing.Size(36, 23);
+			txtMagicDefWldMax.TabIndex = 101;
+			txtMagicDefWldMax.Text = "999";
+			txtMagicDefWldMax.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			txtMagicDefWldMax.TextChanged += txtFilter_TextChanged;
+			// 
+			// label40
+			// 
+			label40.AutoSize = true;
+			label40.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
+			label40.Location = new System.Drawing.Point(212, 393);
+			label40.Name = "label40";
+			label40.Size = new System.Drawing.Size(195, 15);
+			label40.TabIndex = 100;
+			label40.Text = "Wield Requirements - Defense Skills";
+			toolTip2.SetToolTip(label40, resources.GetString("label40.ToolTip"));
+			// 
+			// toolTip1
+			// 
+			toolTip1.ToolTipTitle = "Activation Requirements";
+			// 
+			// toolTip2
+			// 
+			toolTip2.ToolTipTitle = "Wield Requirements - Defense Skills";
+			// 
 			// FiltersControl
 			// 
 			AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
 			AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			Controls.Add(label34);
+			Controls.Add(txtMissileDefWldMin);
+			Controls.Add(label35);
+			Controls.Add(txtMissileDefWldMax);
+			Controls.Add(label36);
+			Controls.Add(txtMeleeDefWldMin);
+			Controls.Add(label37);
+			Controls.Add(txtMeleeDefWldMax);
+			Controls.Add(label38);
+			Controls.Add(txtMagicDefWldMin);
+			Controls.Add(label39);
+			Controls.Add(txtMagicDefWldMax);
+			Controls.Add(label40);
+			Controls.Add(label32);
+			Controls.Add(txtMeleeDefActMin);
+			Controls.Add(label33);
+			Controls.Add(txtMeleeDefActMax);
+			Controls.Add(label30);
+			Controls.Add(txtArcaneLoreActMin);
+			Controls.Add(label31);
+			Controls.Add(txtArcaneLoreActMax);
+			Controls.Add(label28);
+			Controls.Add(txtMissileDefActMin);
+			Controls.Add(label29);
+			Controls.Add(txtMissileDefActMax);
+			Controls.Add(label27);
 			Controls.Add(label22);
 			Controls.Add(txtWieldRequirementSkillMin);
 			Controls.Add(label23);
@@ -1253,5 +1579,33 @@ namespace Mag_SuitBuilder.Equipment
 		private System.Windows.Forms.TextBox txtWieldRequirementLevelMin;
 		private System.Windows.Forms.Label label26;
 		private System.Windows.Forms.TextBox txtWieldRequirementLevelMax;
+		private System.Windows.Forms.Label label27;
+		private System.Windows.Forms.Label label28;
+		private System.Windows.Forms.TextBox txtMissileDefActMin;
+		private System.Windows.Forms.Label label29;
+		private System.Windows.Forms.TextBox txtMissileDefActMax;
+		private System.Windows.Forms.Label label30;
+		private System.Windows.Forms.TextBox txtArcaneLoreActMin;
+		private System.Windows.Forms.Label label31;
+		private System.Windows.Forms.TextBox txtArcaneLoreActMax;
+		private System.Windows.Forms.Label label32;
+		private System.Windows.Forms.TextBox txtMeleeDefActMin;
+		private System.Windows.Forms.Label label33;
+		private System.Windows.Forms.TextBox txtMeleeDefActMax;
+		private System.Windows.Forms.Label label34;
+		private System.Windows.Forms.TextBox txtMissileDefWldMin;
+		private System.Windows.Forms.Label label35;
+		private System.Windows.Forms.TextBox txtMissileDefWldMax;
+		private System.Windows.Forms.Label label36;
+		private System.Windows.Forms.TextBox txtMeleeDefWldMin;
+		private System.Windows.Forms.Label label37;
+		private System.Windows.Forms.TextBox txtMeleeDefWldMax;
+		private System.Windows.Forms.Label label38;
+		private System.Windows.Forms.TextBox txtMagicDefWldMin;
+		private System.Windows.Forms.Label label39;
+		private System.Windows.Forms.TextBox txtMagicDefWldMax;
+		private System.Windows.Forms.Label label40;
+		private System.Windows.Forms.ToolTip toolTip1;
+		private System.Windows.Forms.ToolTip toolTip2;
 	}
 }

--- a/Mag-SuitBuilder/Equipment/FiltersControl.Designer.cs
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.Designer.cs
@@ -119,27 +119,21 @@ namespace Mag_SuitBuilder.Equipment
 			txtWieldRequirementLevelMax = new System.Windows.Forms.TextBox();
 			label27 = new System.Windows.Forms.Label();
 			label28 = new System.Windows.Forms.Label();
-			txtMissileDefActMin = new System.Windows.Forms.TextBox();
 			label29 = new System.Windows.Forms.Label();
 			txtMissileDefActMax = new System.Windows.Forms.TextBox();
 			label30 = new System.Windows.Forms.Label();
-			txtArcaneLoreActMin = new System.Windows.Forms.TextBox();
 			label31 = new System.Windows.Forms.Label();
 			txtArcaneLoreActMax = new System.Windows.Forms.TextBox();
 			label32 = new System.Windows.Forms.Label();
-			txtMeleeDefActMin = new System.Windows.Forms.TextBox();
 			label33 = new System.Windows.Forms.Label();
 			txtMeleeDefActMax = new System.Windows.Forms.TextBox();
 			label34 = new System.Windows.Forms.Label();
-			txtMissileDefWldMin = new System.Windows.Forms.TextBox();
 			label35 = new System.Windows.Forms.Label();
 			txtMissileDefWldMax = new System.Windows.Forms.TextBox();
 			label36 = new System.Windows.Forms.Label();
-			txtMeleeDefWldMin = new System.Windows.Forms.TextBox();
 			label37 = new System.Windows.Forms.Label();
 			txtMeleeDefWldMax = new System.Windows.Forms.TextBox();
 			label38 = new System.Windows.Forms.Label();
-			txtMagicDefWldMin = new System.Windows.Forms.TextBox();
 			label39 = new System.Windows.Forms.Label();
 			txtMagicDefWldMax = new System.Windows.Forms.TextBox();
 			label40 = new System.Windows.Forms.Label();
@@ -1101,45 +1095,34 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			label27.AutoSize = true;
 			label27.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
-			label27.Location = new System.Drawing.Point(271, 256);
+			label27.Location = new System.Drawing.Point(266, 256);
 			label27.Name = "label27";
 			label27.Size = new System.Drawing.Size(137, 15);
 			label27.TabIndex = 87;
 			label27.Text = "Activation Requirements";
-			toolTip1.SetToolTip(label27, resources.GetString("label27.ToolTip"));
+			toolTip1.SetToolTip(label27, "Optionally restrict items by their Activation Requirement.  Typically setting the max value to your buffed skill value.");
 			// 
 			// label28
 			// 
 			label28.AutoSize = true;
-			label28.Location = new System.Drawing.Point(188, 339);
+			label28.Location = new System.Drawing.Point(240, 339);
 			label28.Name = "label28";
 			label28.Size = new System.Drawing.Size(91, 15);
 			label28.TabIndex = 91;
 			label28.Text = "Missile Defense:";
 			// 
-			// txtMissileDefActMin
-			// 
-			txtMissileDefActMin.Location = new System.Drawing.Point(283, 336);
-			txtMissileDefActMin.MaxLength = 3;
-			txtMissileDefActMin.Name = "txtMissileDefActMin";
-			txtMissileDefActMin.Size = new System.Drawing.Size(36, 23);
-			txtMissileDefActMin.TabIndex = 90;
-			txtMissileDefActMin.Text = "0";
-			txtMissileDefActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtMissileDefActMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label29
 			// 
 			label29.AutoSize = true;
-			label29.Location = new System.Drawing.Point(322, 339);
+			label29.Location = new System.Drawing.Point(336, 339);
 			label29.Name = "label29";
-			label29.Size = new System.Drawing.Size(42, 15);
+			label29.Size = new System.Drawing.Size(23, 15);
 			label29.TabIndex = 89;
-			label29.Text = ">= =<";
+			label29.Text = "=<";
 			// 
 			// txtMissileDefActMax
 			// 
-			txtMissileDefActMax.Location = new System.Drawing.Point(367, 336);
+			txtMissileDefActMax.Location = new System.Drawing.Point(362, 336);
 			txtMissileDefActMax.MaxLength = 3;
 			txtMissileDefActMax.Name = "txtMissileDefActMax";
 			txtMissileDefActMax.Size = new System.Drawing.Size(36, 23);
@@ -1151,35 +1134,24 @@ namespace Mag_SuitBuilder.Equipment
 			// label30
 			// 
 			label30.AutoSize = true;
-			label30.Location = new System.Drawing.Point(206, 281);
+			label30.Location = new System.Drawing.Point(258, 281);
 			label30.Name = "label30";
 			label30.Size = new System.Drawing.Size(73, 15);
 			label30.TabIndex = 95;
 			label30.Text = "Arcane Lore:";
 			// 
-			// txtArcaneLoreActMin
-			// 
-			txtArcaneLoreActMin.Location = new System.Drawing.Point(283, 278);
-			txtArcaneLoreActMin.MaxLength = 3;
-			txtArcaneLoreActMin.Name = "txtArcaneLoreActMin";
-			txtArcaneLoreActMin.Size = new System.Drawing.Size(36, 23);
-			txtArcaneLoreActMin.TabIndex = 94;
-			txtArcaneLoreActMin.Text = "0";
-			txtArcaneLoreActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtArcaneLoreActMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label31
 			// 
 			label31.AutoSize = true;
-			label31.Location = new System.Drawing.Point(322, 281);
+			label31.Location = new System.Drawing.Point(334, 281);
 			label31.Name = "label31";
-			label31.Size = new System.Drawing.Size(42, 15);
+			label31.Size = new System.Drawing.Size(23, 15);
 			label31.TabIndex = 93;
-			label31.Text = ">= =<";
+			label31.Text = "=<";
 			// 
 			// txtArcaneLoreActMax
 			// 
-			txtArcaneLoreActMax.Location = new System.Drawing.Point(367, 278);
+			txtArcaneLoreActMax.Location = new System.Drawing.Point(362, 278);
 			txtArcaneLoreActMax.MaxLength = 3;
 			txtArcaneLoreActMax.Name = "txtArcaneLoreActMax";
 			txtArcaneLoreActMax.Size = new System.Drawing.Size(36, 23);
@@ -1191,35 +1163,24 @@ namespace Mag_SuitBuilder.Equipment
 			// label32
 			// 
 			label32.AutoSize = true;
-			label32.Location = new System.Drawing.Point(192, 310);
+			label32.Location = new System.Drawing.Point(244, 310);
 			label32.Name = "label32";
 			label32.Size = new System.Drawing.Size(87, 15);
 			label32.TabIndex = 99;
 			label32.Text = "Melee Defense:";
 			// 
-			// txtMeleeDefActMin
-			// 
-			txtMeleeDefActMin.Location = new System.Drawing.Point(283, 307);
-			txtMeleeDefActMin.MaxLength = 3;
-			txtMeleeDefActMin.Name = "txtMeleeDefActMin";
-			txtMeleeDefActMin.Size = new System.Drawing.Size(36, 23);
-			txtMeleeDefActMin.TabIndex = 98;
-			txtMeleeDefActMin.Text = "0";
-			txtMeleeDefActMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtMeleeDefActMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label33
 			// 
 			label33.AutoSize = true;
-			label33.Location = new System.Drawing.Point(322, 310);
+			label33.Location = new System.Drawing.Point(335, 310);
 			label33.Name = "label33";
-			label33.Size = new System.Drawing.Size(42, 15);
+			label33.Size = new System.Drawing.Size(23, 15);
 			label33.TabIndex = 97;
-			label33.Text = ">= =<";
+			label33.Text = "=<";
 			// 
 			// txtMeleeDefActMax
 			// 
-			txtMeleeDefActMax.Location = new System.Drawing.Point(367, 307);
+			txtMeleeDefActMax.Location = new System.Drawing.Point(362, 307);
 			txtMeleeDefActMax.MaxLength = 3;
 			txtMeleeDefActMax.Name = "txtMeleeDefActMax";
 			txtMeleeDefActMax.Size = new System.Drawing.Size(36, 23);
@@ -1231,35 +1192,24 @@ namespace Mag_SuitBuilder.Equipment
 			// label34
 			// 
 			label34.AutoSize = true;
-			label34.Location = new System.Drawing.Point(187, 447);
+			label34.Location = new System.Drawing.Point(240, 447);
 			label34.Name = "label34";
 			label34.Size = new System.Drawing.Size(91, 15);
 			label34.TabIndex = 112;
 			label34.Text = "Missile Defense:";
 			// 
-			// txtMissileDefWldMin
-			// 
-			txtMissileDefWldMin.Location = new System.Drawing.Point(282, 444);
-			txtMissileDefWldMin.MaxLength = 3;
-			txtMissileDefWldMin.Name = "txtMissileDefWldMin";
-			txtMissileDefWldMin.Size = new System.Drawing.Size(36, 23);
-			txtMissileDefWldMin.TabIndex = 111;
-			txtMissileDefWldMin.Text = "0";
-			txtMissileDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtMissileDefWldMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label35
 			// 
 			label35.AutoSize = true;
-			label35.Location = new System.Drawing.Point(322, 447);
+			label35.Location = new System.Drawing.Point(336, 447);
 			label35.Name = "label35";
-			label35.Size = new System.Drawing.Size(42, 15);
+			label35.Size = new System.Drawing.Size(23, 15);
 			label35.TabIndex = 110;
-			label35.Text = ">= =<";
+			label35.Text = "=<";
 			// 
 			// txtMissileDefWldMax
 			// 
-			txtMissileDefWldMax.Location = new System.Drawing.Point(367, 444);
+			txtMissileDefWldMax.Location = new System.Drawing.Point(362, 444);
 			txtMissileDefWldMax.MaxLength = 3;
 			txtMissileDefWldMax.Name = "txtMissileDefWldMax";
 			txtMissileDefWldMax.Size = new System.Drawing.Size(36, 23);
@@ -1271,35 +1221,24 @@ namespace Mag_SuitBuilder.Equipment
 			// label36
 			// 
 			label36.AutoSize = true;
-			label36.Location = new System.Drawing.Point(192, 418);
+			label36.Location = new System.Drawing.Point(245, 418);
 			label36.Name = "label36";
 			label36.Size = new System.Drawing.Size(87, 15);
 			label36.TabIndex = 108;
 			label36.Text = "Melee Defense:";
 			// 
-			// txtMeleeDefWldMin
-			// 
-			txtMeleeDefWldMin.Location = new System.Drawing.Point(282, 415);
-			txtMeleeDefWldMin.MaxLength = 3;
-			txtMeleeDefWldMin.Name = "txtMeleeDefWldMin";
-			txtMeleeDefWldMin.Size = new System.Drawing.Size(36, 23);
-			txtMeleeDefWldMin.TabIndex = 107;
-			txtMeleeDefWldMin.Text = "0";
-			txtMeleeDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtMeleeDefWldMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label37
 			// 
 			label37.AutoSize = true;
-			label37.Location = new System.Drawing.Point(322, 418);
+			label37.Location = new System.Drawing.Point(336, 418);
 			label37.Name = "label37";
-			label37.Size = new System.Drawing.Size(42, 15);
+			label37.Size = new System.Drawing.Size(23, 15);
 			label37.TabIndex = 106;
-			label37.Text = ">= =<";
+			label37.Text = "=<";
 			// 
 			// txtMeleeDefWldMax
 			// 
-			txtMeleeDefWldMax.Location = new System.Drawing.Point(367, 415);
+			txtMeleeDefWldMax.Location = new System.Drawing.Point(362, 415);
 			txtMeleeDefWldMax.MaxLength = 3;
 			txtMeleeDefWldMax.Name = "txtMeleeDefWldMax";
 			txtMeleeDefWldMax.Size = new System.Drawing.Size(36, 23);
@@ -1311,35 +1250,24 @@ namespace Mag_SuitBuilder.Equipment
 			// label38
 			// 
 			label38.AutoSize = true;
-			label38.Location = new System.Drawing.Point(190, 476);
+			label38.Location = new System.Drawing.Point(243, 476);
 			label38.Name = "label38";
 			label38.Size = new System.Drawing.Size(88, 15);
 			label38.TabIndex = 104;
 			label38.Text = "Magic Defense:";
 			// 
-			// txtMagicDefWldMin
-			// 
-			txtMagicDefWldMin.Location = new System.Drawing.Point(282, 473);
-			txtMagicDefWldMin.MaxLength = 3;
-			txtMagicDefWldMin.Name = "txtMagicDefWldMin";
-			txtMagicDefWldMin.Size = new System.Drawing.Size(36, 23);
-			txtMagicDefWldMin.TabIndex = 103;
-			txtMagicDefWldMin.Text = "0";
-			txtMagicDefWldMin.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			txtMagicDefWldMin.TextChanged += txtFilter_TextChanged;
-			// 
 			// label39
 			// 
 			label39.AutoSize = true;
-			label39.Location = new System.Drawing.Point(322, 476);
+			label39.Location = new System.Drawing.Point(336, 476);
 			label39.Name = "label39";
-			label39.Size = new System.Drawing.Size(42, 15);
+			label39.Size = new System.Drawing.Size(23, 15);
 			label39.TabIndex = 102;
-			label39.Text = ">= =<";
+			label39.Text = "=<";
 			// 
 			// txtMagicDefWldMax
 			// 
-			txtMagicDefWldMax.Location = new System.Drawing.Point(367, 473);
+			txtMagicDefWldMax.Location = new System.Drawing.Point(362, 473);
 			txtMagicDefWldMax.MaxLength = 3;
 			txtMagicDefWldMax.Name = "txtMagicDefWldMax";
 			txtMagicDefWldMax.Size = new System.Drawing.Size(36, 23);
@@ -1352,7 +1280,7 @@ namespace Mag_SuitBuilder.Equipment
 			// 
 			label40.AutoSize = true;
 			label40.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, 0);
-			label40.Location = new System.Drawing.Point(212, 393);
+			label40.Location = new System.Drawing.Point(207, 393);
 			label40.Name = "label40";
 			label40.Size = new System.Drawing.Size(195, 15);
 			label40.TabIndex = 100;
@@ -1372,28 +1300,22 @@ namespace Mag_SuitBuilder.Equipment
 			AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
 			AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			Controls.Add(label34);
-			Controls.Add(txtMissileDefWldMin);
 			Controls.Add(label35);
 			Controls.Add(txtMissileDefWldMax);
 			Controls.Add(label36);
-			Controls.Add(txtMeleeDefWldMin);
 			Controls.Add(label37);
 			Controls.Add(txtMeleeDefWldMax);
 			Controls.Add(label38);
-			Controls.Add(txtMagicDefWldMin);
 			Controls.Add(label39);
 			Controls.Add(txtMagicDefWldMax);
 			Controls.Add(label40);
 			Controls.Add(label32);
-			Controls.Add(txtMeleeDefActMin);
 			Controls.Add(label33);
 			Controls.Add(txtMeleeDefActMax);
 			Controls.Add(label30);
-			Controls.Add(txtArcaneLoreActMin);
 			Controls.Add(label31);
 			Controls.Add(txtArcaneLoreActMax);
 			Controls.Add(label28);
-			Controls.Add(txtMissileDefActMin);
 			Controls.Add(label29);
 			Controls.Add(txtMissileDefActMax);
 			Controls.Add(label27);
@@ -1581,27 +1503,21 @@ namespace Mag_SuitBuilder.Equipment
 		private System.Windows.Forms.TextBox txtWieldRequirementLevelMax;
 		private System.Windows.Forms.Label label27;
 		private System.Windows.Forms.Label label28;
-		private System.Windows.Forms.TextBox txtMissileDefActMin;
 		private System.Windows.Forms.Label label29;
 		private System.Windows.Forms.TextBox txtMissileDefActMax;
 		private System.Windows.Forms.Label label30;
-		private System.Windows.Forms.TextBox txtArcaneLoreActMin;
 		private System.Windows.Forms.Label label31;
 		private System.Windows.Forms.TextBox txtArcaneLoreActMax;
 		private System.Windows.Forms.Label label32;
-		private System.Windows.Forms.TextBox txtMeleeDefActMin;
 		private System.Windows.Forms.Label label33;
 		private System.Windows.Forms.TextBox txtMeleeDefActMax;
 		private System.Windows.Forms.Label label34;
-		private System.Windows.Forms.TextBox txtMissileDefWldMin;
 		private System.Windows.Forms.Label label35;
 		private System.Windows.Forms.TextBox txtMissileDefWldMax;
 		private System.Windows.Forms.Label label36;
-		private System.Windows.Forms.TextBox txtMeleeDefWldMin;
 		private System.Windows.Forms.Label label37;
 		private System.Windows.Forms.TextBox txtMeleeDefWldMax;
 		private System.Windows.Forms.Label label38;
-		private System.Windows.Forms.TextBox txtMagicDefWldMin;
 		private System.Windows.Forms.Label label39;
 		private System.Windows.Forms.TextBox txtMagicDefWldMax;
 		private System.Windows.Forms.Label label40;

--- a/Mag-SuitBuilder/Equipment/FiltersControl.cs
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.cs
@@ -338,7 +338,7 @@ namespace Mag_SuitBuilder.Equipment
 				}
 			}
 
-
+			
 			// Wield Requirements
 			if (int.TryParse(txtWieldRequirementLevelMin.Text, out value))
 			{
@@ -364,6 +364,121 @@ namespace Mag_SuitBuilder.Equipment
 					return false;
 			}
 
+			// Defense Skill Wield Requirement filters - These overlap with more generic filters above.
+			// Most restrictive wins, allowing users to optionally supply more granualy filters
+			// where they want to distinguish between their different skills and further differentiate base wield requirements versus buffed acivation requirements (further below).
+			int wieldSkill = mwo.Values(IntValueKey.WieldSkillType, 0); // Dictionaries.SkillInfo[wieldSkill]
+			int wieldSkillLevelRequ = mwo.Values(IntValueKey.WieldDifficulty, 0);
+			int meleeDWldMin=0, missileDWldMin=0, magicDWldMin=0;
+			int.TryParse(txtMeleeDefWldMin.Text, out meleeDWldMin);
+			int.TryParse(txtMissileDefWldMin.Text, out missileDWldMin);
+			int.TryParse(txtMagicDefWldMin.Text, out magicDWldMin);
+			if (mwo.Values(IntValueKey.WieldRequirements, 0) != 7) // WieldSkillType can be interpretted as a skill, is NOT a Level requ.
+			{				
+				if (wieldSkill == (int)6) // Melee Defense Wield Requirement filter
+				{
+					if (meleeDWldMin > wieldSkillLevelRequ)
+					{
+						return false;
+					}
+
+					if (int.TryParse(txtMeleeDefWldMax.Text, out int melDMax) && wieldSkillLevelRequ > melDMax)
+					{
+						return false;
+					}
+				}
+				else if (meleeDWldMin > 0) 
+				{
+					return false;// if min filter is used, remove any that don't have this requirement
+				}
+
+				if (wieldSkill == (int)7) // Missile Defense Wield Requirement filter
+				{
+					if (missileDWldMin > wieldSkillLevelRequ)
+					{
+						return false;
+					}
+					if (int.TryParse(txtMissileDefWldMax.Text, out int mslDMax) && wieldSkillLevelRequ > mslDMax)
+					{
+						return false;
+					}
+				}
+				else if (missileDWldMin > 0)
+				{
+					return false;// if min filter is used, remove any that don't have this requirement
+				}
+
+				if (wieldSkill == (int)15) // Magic Defense Wield Requirement filter
+				{
+					if (magicDWldMin > wieldSkillLevelRequ)
+					{
+						return false;
+					}
+					if (int.TryParse(txtMagicDefWldMax.Text, out int magDMax) && wieldSkillLevelRequ > magDMax)
+					{
+						return false;
+					}
+				}
+				else if (magicDWldMin > 0)
+				{
+					return false;// if min filter is used, remove any that don't have this requirement
+				}
+			}
+			else if (meleeDWldMin > 0 || missileDWldMin > 0 || magicDWldMin > 0)
+			{
+				return false;// if any min filters used, items without matching requirements excluded
+			}
+
+			// Activation Requirements
+			int loreRequirement = mwo.Values(IntValueKey.ItemDifficulty, 0);// Item's Arcane Lore Activation Requirement			
+			// Arcane Lore activation filter
+			if( int.TryParse(txtArcaneLoreActMin.Text, out int alMin) && alMin > loreRequirement )
+			{
+				return false;
+			}
+
+			if( int.TryParse(txtArcaneLoreActMax.Text, out int alMax) && loreRequirement > alMax)
+			{
+				return false;
+			}
+
+			// Skill based Activation Requirements for spells (MissileDef, MeleeDef etc.) These are NOT Wield requirements
+			int activationSkill = mwo.Values(IntValueKey.AppraisalItemSkill, 0);
+			int activationSkillLevelRequirement = mwo.Values(IntValueKey.ItemSkillLevelLimit, 0);
+ 
+			// Melee Defense activation filter
+			if (activationSkill == (int)6) // Skill type 6 == Melee Defense
+			{
+				if (int.TryParse(txtMeleeDefActMin.Text, out int meleeDActMin) && meleeDActMin > activationSkillLevelRequirement) 
+				{
+					return false;
+				}
+				if (int.TryParse(txtMeleeDefActMax.Text, out int meleeDActMax) && activationSkillLevelRequirement > meleeDActMax)
+				{
+					return false;
+				}
+			}
+			else if(int.TryParse(txtMeleeDefActMin.Text, out int meleeDActMin) && meleeDActMin > 0) 
+			{
+				return false;// if min filter is used, remove any that don't have this requirement
+			}
+
+			// Missile Defense activation filter
+			if (activationSkill == (int)7) // Skill type 7 == Missile Defense
+			{
+				if (int.TryParse(txtMissileDefActMin.Text, out int mslDActMin) && mslDActMin > activationSkillLevelRequirement)
+				{
+					return false;
+				}
+				if (int.TryParse(txtMissileDefActMax.Text, out int mslDActMax) && activationSkillLevelRequirement > mslDActMax)
+				{
+					return false;
+				}
+			}
+			else if (int.TryParse(txtMissileDefActMin.Text, out int mslDActMin) && mslDActMin > 0)
+			{
+				return false;// if min filter is used, remove any that don't have this requirement
+			}
 
 			// Spell Selector
 			if (cantripSelectorControl1.Count > 0)

--- a/Mag-SuitBuilder/Equipment/FiltersControl.cs
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.cs
@@ -366,77 +366,34 @@ namespace Mag_SuitBuilder.Equipment
 
 			// Defense Skill Wield Requirement filters - These overlap with more generic filters above.
 			// Most restrictive wins, allowing users to optionally supply more granualy filters
-			// where they want to distinguish between their different skills and further differentiate base wield requirements versus buffed acivation requirements (further below).
 			int wieldSkill = mwo.Values(IntValueKey.WieldSkillType, 0); // Dictionaries.SkillInfo[wieldSkill]
 			int wieldSkillLevelRequ = mwo.Values(IntValueKey.WieldDifficulty, 0);
-			int meleeDWldMin=0, missileDWldMin=0, magicDWldMin=0;
-			int.TryParse(txtMeleeDefWldMin.Text, out meleeDWldMin);
-			int.TryParse(txtMissileDefWldMin.Text, out missileDWldMin);
-			int.TryParse(txtMagicDefWldMin.Text, out magicDWldMin);
-			if (mwo.Values(IntValueKey.WieldRequirements, 0) != 7) // WieldSkillType can be interpretted as a skill, is NOT a Level requ.
-			{				
-				if (wieldSkill == (int)6) // Melee Defense Wield Requirement filter
-				{
-					if (meleeDWldMin > wieldSkillLevelRequ)
-					{
-						return false;
-					}
-
-					if (int.TryParse(txtMeleeDefWldMax.Text, out int melDMax) && wieldSkillLevelRequ > melDMax)
-					{
-						return false;
-					}
-				}
-				else if (meleeDWldMin > 0) 
-				{
-					return false;// if min filter is used, remove any that don't have this requirement
-				}
-
-				if (wieldSkill == (int)7) // Missile Defense Wield Requirement filter
-				{
-					if (missileDWldMin > wieldSkillLevelRequ)
-					{
-						return false;
-					}
-					if (int.TryParse(txtMissileDefWldMax.Text, out int mslDMax) && wieldSkillLevelRequ > mslDMax)
-					{
-						return false;
-					}
-				}
-				else if (missileDWldMin > 0)
-				{
-					return false;// if min filter is used, remove any that don't have this requirement
-				}
-
-				if (wieldSkill == (int)15) // Magic Defense Wield Requirement filter
-				{
-					if (magicDWldMin > wieldSkillLevelRequ)
-					{
-						return false;
-					}
-					if (int.TryParse(txtMagicDefWldMax.Text, out int magDMax) && wieldSkillLevelRequ > magDMax)
-					{
-						return false;
-					}
-				}
-				else if (magicDWldMin > 0)
-				{
-					return false;// if min filter is used, remove any that don't have this requirement
-				}
-			}
-			else if (meleeDWldMin > 0 || missileDWldMin > 0 || magicDWldMin > 0)
+			if (mwo.Values(IntValueKey.WieldRequirements, 0) != 7) // Check that WieldSkillType can be interpretted as a skill, is NOT a Level requ.
 			{
-				return false;// if any min filters used, items without matching requirements excluded
-			}
+				// Melee Defense Wield Requirement filter
+				if (wieldSkill == (int)6 && int.TryParse(txtMeleeDefWldMax.Text, out int melDMax)
+					&& wieldSkillLevelRequ > melDMax)
+				{
+					return false;
+				}
 
-			// Activation Requirements
-			int loreRequirement = mwo.Values(IntValueKey.ItemDifficulty, 0);// Item's Arcane Lore Activation Requirement			
+				// Missile Defense Wield Requirement filter
+				if (wieldSkill == (int)7 && int.TryParse(txtMissileDefWldMax.Text, out int mslDMax)
+					&& wieldSkillLevelRequ > mslDMax)
+				{
+					return false;
+				}
+
+				// Magic Defense Wield Requirement filter
+				if (wieldSkill == (int)15 && int.TryParse(txtMagicDefWldMax.Text, out int magDMax)
+					&& wieldSkillLevelRequ > magDMax)
+				{
+					return false;
+				}				
+			}
+						
+			int loreRequirement = mwo.Values(IntValueKey.ItemDifficulty, 0);// Item's Arcane Lore Activation Requirement		
 			// Arcane Lore activation filter
-			if( int.TryParse(txtArcaneLoreActMin.Text, out int alMin) && alMin > loreRequirement )
-			{
-				return false;
-			}
-
 			if( int.TryParse(txtArcaneLoreActMax.Text, out int alMax) && loreRequirement > alMax)
 			{
 				return false;
@@ -445,39 +402,19 @@ namespace Mag_SuitBuilder.Equipment
 			// Skill based Activation Requirements for spells (MissileDef, MeleeDef etc.) These are NOT Wield requirements
 			int activationSkill = mwo.Values(IntValueKey.AppraisalItemSkill, 0);
 			int activationSkillLevelRequirement = mwo.Values(IntValueKey.ItemSkillLevelLimit, 0);
- 
-			// Melee Defense activation filter
-			if (activationSkill == (int)6) // Skill type 6 == Melee Defense
+
+			// Melee Defense activation filter, Skill type 6 == Melee Defense
+			if (activationSkill == (int)6 && int.TryParse(txtMeleeDefActMax.Text, out int meleeDActMax)
+				&& activationSkillLevelRequirement > meleeDActMax)
 			{
-				if (int.TryParse(txtMeleeDefActMin.Text, out int meleeDActMin) && meleeDActMin > activationSkillLevelRequirement) 
-				{
-					return false;
-				}
-				if (int.TryParse(txtMeleeDefActMax.Text, out int meleeDActMax) && activationSkillLevelRequirement > meleeDActMax)
-				{
-					return false;
-				}
-			}
-			else if(int.TryParse(txtMeleeDefActMin.Text, out int meleeDActMin) && meleeDActMin > 0) 
-			{
-				return false;// if min filter is used, remove any that don't have this requirement
+				return false;
 			}
 
-			// Missile Defense activation filter
-			if (activationSkill == (int)7) // Skill type 7 == Missile Defense
+			// Missile Defense activation filter, Skill type 7 == Missile Defense
+			if (activationSkill == (int)7 && int.TryParse(txtMissileDefActMax.Text, out int mslDActMax)
+				&& activationSkillLevelRequirement > mslDActMax)
 			{
-				if (int.TryParse(txtMissileDefActMin.Text, out int mslDActMin) && mslDActMin > activationSkillLevelRequirement)
-				{
-					return false;
-				}
-				if (int.TryParse(txtMissileDefActMax.Text, out int mslDActMax) && activationSkillLevelRequirement > mslDActMax)
-				{
-					return false;
-				}
-			}
-			else if (int.TryParse(txtMissileDefActMin.Text, out int mslDActMin) && mslDActMin > 0)
-			{
-				return false;// if min filter is used, remove any that don't have this requirement
+				return false;
 			}
 
 			// Spell Selector

--- a/Mag-SuitBuilder/Equipment/FiltersControl.resx
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
@@ -117,4 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="label27.ToolTip" xml:space="preserve">
+    <value>Optionally restrict items by their Activation Requirement.  Typically setting the max value to your buffed skill value.
+Setting a non-zero Min value excludes any items without that skill requirement.  Multiple min values from different skills will require an item to have requirements from ALL of those skills.</value>
+  </data>
+  <metadata name="toolTip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>115, 17</value>
+  </metadata>
+  <data name="label40.ToolTip" xml:space="preserve">
+    <value>Typically set the max field to the character's corresponding base skill value.  These filters provide granular resictions for each skill.
+Note: Wield Requirements "Skill" field covers wield requirements for these defensive skills as well as weapon skills,
+and can be used to apply generic restriction for all wield requirement skills.  Most restrictive filter will exclude items from results.
+Setting a non-zero Min value excludes any items without that skill requirement.  Multiple min values from different skills will require an item to have requirements from ALL of those skills.</value>
+  </data>
 </root>

--- a/Mag-SuitBuilder/Equipment/FiltersControl.resx
+++ b/Mag-SuitBuilder/Equipment/FiltersControl.resx
@@ -120,17 +120,12 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="label27.ToolTip" xml:space="preserve">
-    <value>Optionally restrict items by their Activation Requirement.  Typically setting the max value to your buffed skill value.
-Setting a non-zero Min value excludes any items without that skill requirement.  Multiple min values from different skills will require an item to have requirements from ALL of those skills.</value>
-  </data>
   <metadata name="toolTip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>115, 17</value>
   </metadata>
   <data name="label40.ToolTip" xml:space="preserve">
-    <value>Typically set the max field to the character's corresponding base skill value.  These filters provide granular resictions for each skill.
+    <value>Typically set the max filter to the character's corresponding base skill value.  These filters provide granular resictions for each skill.
 Note: Wield Requirements "Skill" field covers wield requirements for these defensive skills as well as weapon skills,
-and can be used to apply generic restriction for all wield requirement skills.  Most restrictive filter will exclude items from results.
-Setting a non-zero Min value excludes any items without that skill requirement.  Multiple min values from different skills will require an item to have requirements from ALL of those skills.</value>
+and can be used to apply generic restriction for all wield requirement skills.  Most restrictive filter will exclude items from results.</value>
   </data>
 </root>

--- a/Shared/ItemInfo.cs
+++ b/Shared/ItemInfo.cs
@@ -253,6 +253,8 @@ namespace Mag.Shared
 			if (mwo.Values(IntValueKey.WieldDifficulty) > 0)
 			{
 				// I don't quite understand this.
+				// WieldRequirements==7 means SkillType doesn't represent skill names, instead SkillType==1 means Level (instead of Axe)
+				// Cloaks for example have Player Level wield requirement
 				if (mwo.Values(IntValueKey.WieldRequirements) == 7 && mwo.Values(IntValueKey.WieldSkillType) == 1)
 					sb.Append(", Wield Lvl " + mwo.Values(IntValueKey.WieldDifficulty));
 				else


### PR DESCRIPTION
feature: Granular activation and wield filters for arcane lore and defense skills.

- Allows user to build suits that with maximum arcane lore or defense skill activation requirements, so that they can swap suits without requiring a arcane lore rare nor tinkering wield requirements.
- Allows base defense skill values to be entered separately for wield requirements.

<img width="593" height="595" alt="image" src="https://github.com/user-attachments/assets/cc6089eb-3f49-49f1-8007-607eb8aa1231" />

<img width="894" height="123" alt="image" src="https://github.com/user-attachments/assets/7662c24f-9f11-4247-85ad-ef04532d56f5" />

<img width="655" height="76" alt="image" src="https://github.com/user-attachments/assets/4319ec3b-f75f-4a38-8b03-8e1b37167316" />

